### PR TITLE
Fix push install

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,6 @@ android {
 }
 
 dependencies {
-    api 'com.clevertap.android:clevertap-android-sdk:4.0.4'
+    api 'com.clevertap.android:clevertap-android-sdk:4.2.0'
 }
 

--- a/src/main/java/com/mparticle/kits/CleverTapKit.java
+++ b/src/main/java/com/mparticle/kits/CleverTapKit.java
@@ -121,7 +121,7 @@ public class CleverTapKit extends KitIntegration implements
 
     @Override
     public void setInstallReferrer(android.content.Intent intent) {
-        cl.pushInstallReferrer(intent);
+        cl.pushInstallReferrer(intent.getDataString());
     }
 
     @Override


### PR DESCRIPTION
Based off a Dependabot PR to upgrade the underlying SDK

in the new version of Clevertap's SDK, the setInstallReferrer method no longer takes an intent. According to their Javadocs, "This method is used to push install referrer via url String". `Intent.getData()` is the URI of the intent, and `Intent.getDataString()` is the Stringified version of the same URI.

Ticket #71810