### PR TITLE
chore: update minSdk to 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'com.mparticle.kit'
 
 android {
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
     }
 }
 


### PR DESCRIPTION
# Summary

upgrade to minSdk 16 to match underlying Clevertap SDK
